### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ applications that use the [yarn](https://yarnpkg.com) package manager.
 ## Integration
 
 The Yarn Install CNB provides `node_modules` as a dependency. Downstream
-buildpacks can require the `node_modules` dependency by generating a [Build Plan
-TOML](https://github.com/buildpacks/spec/blob/master/buildpack.md#build-plan-toml)
+buildpacks can require the `node_modules` dependency by generating a [Build
+Plan TOML](https://github.com/buildpacks/spec/blob/master/buildpack.md#build-plan-toml)
 file that looks like the following:
 
 ```toml
@@ -48,9 +48,7 @@ To package this buildpack for consumption:
 ./scripts/package.sh --version 2.6.6
 ```
 
-This will build the buildpack for all target architectures specified in
-`buildpack.toml` (amd64 and arm64 by default) and create a single archive
-containing binaries for all architectures in the `build/` directory.
+This will build the buildpack for all target architectures specified in `buildpack.toml` (amd64 and arm64 by default) and create a single archive containing binaries for all architectures in the `build/` directory.
 
 This will create a `buildpackage.cnb` file under the `build` directory which you
 can use to build your app as follows:
@@ -77,8 +75,7 @@ aws ecr get-login-password --region us-east-1 | \
 The script will automatically:
 - Read target architectures from `buildpack.toml`
 - Extract the buildpack archive
-- Publish each architecture separately with arch-suffixed tags (e.g.,
-  `yarn-install:<version>-amd64`, `yarn-install:<version>-arm64`)
+- Publish each architecture separately with arch-suffixed tags (e.g., `yarn-install:<version>-amd64`, `yarn-install:<version>-arm64`)
 - Create and push a multi-arch manifest list
 
 ## Usage
@@ -108,8 +105,8 @@ To run all integration tests, run:
 
 For most apps, the Yarn Install Buildpack runs fine on the [Base
 builder](https://github.com/paketo-buildpacks/stacks#metadata-for-paketo-buildrun-stack-images).
-But when the app requires compilation of native extensions using `node-gyp`, the
-buildpack requires that you use the [Full
+But when the app requires compilation of native extensions using `node-gyp`,
+the buildpack requires that you use the [Full
 builder](https://github.com/paketo-buildpacks/stacks#metadata-for-paketo-buildrun-stack-images).
 This is because `node-gyp` requires `python` that's absent on the Base builder,
 and the module may require other shared objects.


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
